### PR TITLE
Add force redownload command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This little script will download all the templates at once, so you don't have to
 
 `./pixelarity-download.py <E-MAIL> <PASSWORD>`
 
-To force the redownload of already downloaded themes, supply the `-f` parameter
-with the value `True`.
+To force the redownload of already downloaded themes, supply the `-f` parameter.
 
 To do: Add an update current templates feature.

--- a/README.md
+++ b/README.md
@@ -6,4 +6,7 @@ This little script will download all the templates at once, so you don't have to
 
 `./pixelarity-download.py <E-MAIL> <PASSWORD>`
 
+To force the redownload of already downloaded themes, supply the `-f` parameter
+with the value `True`.
+
 To do: Add an update current templates feature.

--- a/pixelarity-download.py
+++ b/pixelarity-download.py
@@ -30,6 +30,7 @@ def main():
         parser = argparse.ArgumentParser(description='Login to Pixelarity.')
         parser.add_argument("email")
         parser.add_argument("password")
+        parser.add_argument('-f', '--force', help="Force redownload of all themes. Supply `True` or `False`.", required=False)
         args = parser.parse_args()
 
         browser = RoboBrowser()
@@ -46,7 +47,7 @@ def main():
 
         for i in range(len(templates)):
                 print('Downloading https://pixelarity.com/' + templates[i] + '/download/html ...')
-                if not os.path.exists('./px-' + templates[i] + '.zip'):
+                if not os.path.exists('./px-' + templates[i] + '.zip') or (args.force):
                         request = browser.session.get('https://pixelarity.com/' + templates[i] + '/download/html', stream=True)
                         with open('px-' + templates[i] + '.zip', "wb") as temp_zip:
                                 temp_zip.write(request.content)

--- a/pixelarity-download.py
+++ b/pixelarity-download.py
@@ -30,7 +30,7 @@ def main():
         parser = argparse.ArgumentParser(description='Login to Pixelarity.')
         parser.add_argument("email")
         parser.add_argument("password")
-        parser.add_argument('-f', '--force', help="Force redownload of all themes. Supply `True` or `False`.", required=False)
+        parser.add_argument('-f', '--force', help="Force redownload of all themes. Supply `True` or `False`.", action='store_true', required=False)
         args = parser.parse_args()
 
         browser = RoboBrowser()


### PR DESCRIPTION
Now if a user supplies `-f True` or `--force True` anywhere in the command call. It will force the redownload of every theme. This is a way to update the theme files without having to laboriously delete them first.